### PR TITLE
fixted bug where time was only ever set to sunrise or sunset 

### DIFF
--- a/src/main/java/io/github/jack1424/realTimeWeather/RealTimeWeather.java
+++ b/src/main/java/io/github/jack1424/realTimeWeather/RealTimeWeather.java
@@ -161,15 +161,17 @@ public final class RealTimeWeather extends JavaPlugin {
 			sunsetMinutes += 720;
 
 		LocalTime currentTime = LocalTime.of(cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE));
-		int currentMinutes = currentTime.getHour() * 60 + currentTime.getMinute();
+		double currentMinutes = currentTime.getHour() * 60 + currentTime.getMinute();
 
 		if (currentMinutes >= sunriseMinutes && currentMinutes < sunsetMinutes) {
-			return ((currentMinutes - sunriseMinutes) / (sunsetMinutes - sunriseMinutes) * 13569) + 23041;
+			double daytimeFraction=(currentMinutes - sunriseMinutes) / (sunsetMinutes - sunriseMinutes);
+			return (long) (daytimeFraction * 13569) + 23041;
 		} else {
 			if (currentMinutes < sunriseMinutes)
 				currentMinutes += 1440;
-
-			return ((currentMinutes - sunsetMinutes) / (1440 - sunsetMinutes + sunriseMinutes) * 13569) + 12610;
+			
+			double nighttimeFraction=(currentMinutes - sunsetMinutes) / (1440 - sunsetMinutes + sunriseMinutes);
+			return (long)(nighttimeFraction * 13569) + 12610;
 		}
 	}
 


### PR DESCRIPTION
calucation of daytime and night time fractions were being done using integer division resulting in either a 0 or 1.
-change currentMinutes type from int to double, so that floating point division would be used.
-pulled out day time and night time fractions into their own doubles for clarity.
-type cast return values of calculateWorldTime from double to long to maintain previous structure.