### PR TITLE
fix SunriseSunsetRequest to use right config values

### DIFF
--- a/src/main/java/io/github/jack1424/realTimeWeather/RealTimeWeather.java
+++ b/src/main/java/io/github/jack1424/realTimeWeather/RealTimeWeather.java
@@ -87,7 +87,7 @@ public final class RealTimeWeather extends JavaPlugin {
 					if (config.getSunriseSunset().equals("real")) {
 						SunriseSunsetRequestObject sunriseSunset;
 						try {
-							sunriseSunset = new SunriseSunsetRequestObject(config.getTimeZone(), config.getWeatherLatitude(), config.getWeatherLongitude());
+							sunriseSunset = new SunriseSunsetRequestObject(config.getTimeZone(), config.getSunriseSunsetLatitude(), config.getSunriseSunsetLongitude());
 							world.setTime(calculateWorldTime(cal, sunriseSunset.getSunriseTime(), sunriseSunset.getSunsetTime()));
 						} catch (Exception e) {
 							logger.severe(e.getMessage());


### PR DESCRIPTION
The SunriseSunsetRequestObject originally used config.getWeatherLatitude (and longitude). I changed this to use the right values (config.getSunriseSunsetLongitude ...).
This is important because if the weather setting are not set in config, the SunriseSunset request will fail with HTTP error 500.