### PR TITLE
feat: fixed weather sync blocking and crashing servers by moving to async

### DIFF
--- a/src/main/java/io/github/jack1424/realTimeWeather/RealTimeWeather.java
+++ b/src/main/java/io/github/jack1424/realTimeWeather/RealTimeWeather.java
@@ -128,17 +128,21 @@ public final class RealTimeWeather extends JavaPlugin {
 		for (World world : config.getWeatherSyncWorlds())
 			world.setGameRule(GameRule.DO_WEATHER_CYCLE, false);
 
-		getServer().getScheduler().scheduleSyncRepeatingTask(this, () -> {
+		getServer().getScheduler().runTaskTimerAsynchronously(this, () -> {
 			debug("Syncing weather...");
 
 			try {
 				WeatherRequestObject request = new WeatherRequestObject(config.getAPIKey(), config.getWeatherLatitude(), config.getWeatherLongitude());
+				boolean rain = request.isRaining();
+				boolean thunder = request.isThundering();
 
-				debug("Setting weather (Rain: " + request.isRaining() + ", Thunder: " + request.isThundering() + ")...");
-				for (World world : config.getWeatherSyncWorlds()) {
-					world.setStorm(request.isRaining());
-					world.setThundering(request.isThundering());
-				}
+				getServer().getScheduler().runTask(this, () -> {
+					debug("Setting weather (Rain: " + rain + ", Thunder: " + thunder + ")...");
+					for (World world : config.getWeatherSyncWorlds()) {
+						world.setStorm(rain);
+						world.setThundering(thunder);
+					}
+				});
 			} catch (Exception e) {
 				logger.severe("There was an error when attempting to get weather information");
 				debug(e.getMessage());

--- a/src/main/java/io/github/jack1424/realTimeWeather/requests/RequestFunctions.java
+++ b/src/main/java/io/github/jack1424/realTimeWeather/requests/RequestFunctions.java
@@ -6,33 +6,54 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 public class RequestFunctions {
+	private static final int CONNECT_TIMEOUT_MS = 5000;
+	private static final int READ_TIMEOUT_MS = 10000;
+
 	public static Object makeRequest(String URLString) throws IOException, HTTPResponseException, ParseException, URISyntaxException {
-		int responseCode = getResponseCode(URLString);
-		if (responseCode > 399)
-			throw new HTTPResponseException(responseCode);
+		HttpURLConnection con = openConnection(URLString);
+		try {
+			int responseCode = con.getResponseCode();
+			if (responseCode > 399)
+				throw new HTTPResponseException(responseCode);
 
-		Scanner scanner = new Scanner(new URI(URLString).toURL().openStream());
-		StringBuilder response = new StringBuilder();
-		while (scanner.hasNextLine())
-			response.append(scanner.nextLine());
-		scanner.close();
+			StringBuilder response = new StringBuilder();
+			try (InputStream input = con.getInputStream();
+				 Scanner scanner = new Scanner(input, StandardCharsets.UTF_8)) {
+				while (scanner.hasNextLine())
+					response.append(scanner.nextLine());
+			}
 
-		return new JSONParser().parse(response.toString());
+			return new JSONParser().parse(response.toString());
+		} finally {
+			con.disconnect();
+		}
 	}
 
 	public static int getResponseCode(String URLString) throws IOException, URISyntaxException {
+		HttpURLConnection con = openConnection(URLString);
+		try {
+			return con.getResponseCode();
+		} finally {
+			con.disconnect();
+		}
+	}
+
+	private static HttpURLConnection openConnection(String URLString) throws IOException, URISyntaxException {
 		URL url = new URI(URLString).toURL();
 		HttpURLConnection con = (HttpURLConnection) url.openConnection();
 		con.setRequestMethod("GET");
-		con.connect();
-		return con.getResponseCode();
+		con.setConnectTimeout(CONNECT_TIMEOUT_MS);
+		con.setReadTimeout(READ_TIMEOUT_MS);
+		return con;
 	}
 
 	public static String getLatestVersion() throws Exception {


### PR DESCRIPTION
This change moves the weather API request off the main server thread and applies world updates back on the main thread to avoid watchdog stalls. Also adds connect/read timeouts and reuses a single HttpURLConnection per request to prevent indefinite hangs during SSL connect or reads

thought i'd start making PRs for this, a couple of players started reporting this same issue of the plugin crashing servers. 

Closes #24 
Closes #13 