### PR TITLE
feat: use actionbar for "immersive" like alerts 

### DIFF
--- a/src/main/java/io/github/jack1424/realTimeWeather/ConfigManager.java
+++ b/src/main/java/io/github/jack1424/realTimeWeather/ConfigManager.java
@@ -19,12 +19,13 @@ import java.util.TimeZone;
 
 public class ConfigManager {
 	private static final String DEFAULT_TIME_PLACEHOLDER_FORMAT = "HH:mm z";
+	private static final String DEFAULT_ALERT_DELIVERY = "actionbar";
 	private final RealTimeWeather rtw;
 	private final FileConfiguration configFile;
 	private TimeZone timeZone;
 	private boolean debug, timeEnabled, weatherEnabled, timeSyncAllWorlds, weatherSyncAllWorlds, blockTimeSetCommand, blockWeatherCommand, disableBedsAtNight, disableBedsDuringThunder;
 	private long updateCheckInterval, timeSyncInterval, weatherSyncInterval;
-	private String sunriseSunset, sunriseSunsetLatitude, sunriseSunsetLongitude, apiKey, weatherLatitude, weatherLongitude, disableBedsAtNightMessage, disableBedsDuringThunderMessage, sunriseCustomTime, sunsetCustomTime, timePlaceholderFormat;
+	private String sunriseSunset, sunriseSunsetLatitude, sunriseSunsetLongitude, apiKey, weatherLatitude, weatherLongitude, disableBedsAtNightMessage, disableBedsDuringThunderMessage, sunriseCustomTime, sunsetCustomTime, timePlaceholderFormat, alertDelivery;
 	private HashSet<World> timeSyncWorlds, weatherSyncWorlds;
 
 	public ConfigManager(RealTimeWeather rtw) {
@@ -34,6 +35,7 @@ public class ConfigManager {
 
 	public void refreshValues() {
 		setDebugEnabled(configFile.getBoolean("Debug"));
+		setAlertDelivery(configFile.getString("AlertDelivery"));
 
 		setTimeEnabled(configFile.getBoolean("SyncTime"));
 		if (isTimeEnabled())
@@ -117,6 +119,28 @@ public class ConfigManager {
 	public void setDebugEnabled(boolean value) {
 		debug = value;
 		rtw.getLogger().warning("Debug set to " + value);
+	}
+
+	public String getAlertDelivery() {
+		return alertDelivery;
+	}
+
+	public void setAlertDelivery(String value) {
+		if (value == null || isBlank(value)) {
+			alertDelivery = DEFAULT_ALERT_DELIVERY;
+			rtw.debug("AlertDelivery set to default (blank value)");
+			return;
+		}
+
+		String normalized = value.toLowerCase();
+		if (normalized.equals("actionbar") || normalized.equals("chat")) {
+			alertDelivery = normalized;
+			rtw.debug("AlertDelivery set to " + normalized);
+			return;
+		}
+
+		alertDelivery = DEFAULT_ALERT_DELIVERY;
+		rtw.getLogger().warning("AlertDelivery invalid; using default");
 	}
 
 	public boolean isTimeEnabled() {

--- a/src/main/java/io/github/jack1424/realTimeWeather/EventHandlers.java
+++ b/src/main/java/io/github/jack1424/realTimeWeather/EventHandlers.java
@@ -8,6 +8,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.server.ServerCommandEvent;
+import io.github.jack1424.realTimeWeather.utils.TextUtils;
 
 public class EventHandlers implements Listener {
 	private final ConfigManager config;
@@ -39,16 +40,19 @@ public class EventHandlers implements Listener {
 		Player player = event.getPlayer();
 		World playerWorld = player.getWorld();
 		long worldTime = playerWorld.getTime();
+		String disableBedsAtNightMessage = config.getDisableBedsAtNightMessage();
+		String disableBedsDuringThunderMessage = config.getDisableBedsDuringThunderMessage();
+		String alertDelivery = config.getAlertDelivery();
 
 		if (config.isTimeEnabled() && config.getDisableBedsAtNight() && ((!playerWorld.hasStorm() && worldTime >= 12542 && worldTime <= 23459)
 			|| (playerWorld.hasStorm() && worldTime >= 12010 && worldTime <= 23991))) {
 			event.setCancelled(true);
-			player.sendMessage(config.getDisableBedsAtNightMessage());
+			TextUtils.sendPlayerAlert(player, disableBedsAtNightMessage, alertDelivery);
 		}
 
 		if (config.isWeatherEnabled() && config.getDisableBedsDuringThunder() && playerWorld.isThundering()) {
 			event.setCancelled(true);
-			player.sendMessage(config.getDisableBedsDuringThunderMessage());
+			TextUtils.sendPlayerAlert(player, disableBedsDuringThunderMessage, alertDelivery);
 		}
 	}
 }

--- a/src/main/java/io/github/jack1424/realTimeWeather/utils/TextUtils.java
+++ b/src/main/java/io/github/jack1424/realTimeWeather/utils/TextUtils.java
@@ -2,19 +2,41 @@ package io.github.jack1424.realTimeWeather.utils;
 
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+
+import java.lang.reflect.Constructor;
 
 public final class TextUtils {
 	private TextUtils() {
 	}
 
-	public static void sendActionbar(Player player, String message) {
-		if (player == null)
-			return;
+    public static void sendActionbar(Player player, String message) {
+        if (player == null) return;
 
-		String safeMessage = message == null ? "" : message;
-		player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(safeMessage));
-	}
+        String safeMessage = message == null ? "" : message;
+
+        try {
+            String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+
+            Class<?> chatSerializer = Class.forName("net.minecraft.server." + version + ".IChatBaseComponent$ChatSerializer");
+            Object component = chatSerializer.getMethod("a", String.class)
+                    .invoke(null, "{\"text\":\"" + safeMessage + "\"}");
+
+            Class<?> packetClass = Class.forName("net.minecraft.server." + version + ".PacketPlayOutChat");
+            Class<?> baseComponentClass = Class.forName("net.minecraft.server." + version + ".IChatBaseComponent");
+            Constructor<?> packetConstructor = packetClass.getConstructor(baseComponentClass, byte.class);
+            Object packet = packetConstructor.newInstance(component, (byte) 2);
+
+            Object handle = player.getClass().getMethod("getHandle").invoke(player);
+            Object connection = handle.getClass().getField("playerConnection").get(handle);
+            connection.getClass().getMethod("sendPacket", Class.forName("net.minecraft.server." + version + ".Packet"))
+                    .invoke(connection, packet);
+
+        } catch (Exception e) {
+            player.sendMessage(safeMessage);
+        }
+    }
 
 	public static void sendPlayerAlert(Player player, String message, String delivery) {
 		if (player == null)

--- a/src/main/java/io/github/jack1424/realTimeWeather/utils/TextUtils.java
+++ b/src/main/java/io/github/jack1424/realTimeWeather/utils/TextUtils.java
@@ -1,0 +1,31 @@
+package io.github.jack1424.realTimeWeather.utils;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.entity.Player;
+
+public final class TextUtils {
+	private TextUtils() {
+	}
+
+	public static void sendActionbar(Player player, String message) {
+		if (player == null)
+			return;
+
+		String safeMessage = message == null ? "" : message;
+		player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(safeMessage));
+	}
+
+	public static void sendPlayerAlert(Player player, String message, String delivery) {
+		if (player == null)
+			return;
+
+		String safeMessage = message == null ? "" : message;
+		if ("actionbar".equalsIgnoreCase(delivery)) {
+			sendActionbar(player, safeMessage);
+			return;
+		}
+
+		player.sendMessage(safeMessage);
+	}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,6 +35,10 @@ TimeSyncWorlds:
 # Set to false to enable the /time set command (not recommended)                                                     #
 BlockTimeSetCommand: true
 #                                                                                                                    #
+# Choose how player alerts are delivered: actionbar or chat                                                          #
+# This affects messages like blocked beds and blocked commands                                                       #
+AlertDelivery: actionbar
+#                                                                                                                    #
 # Prevent players from sleeping in beds at night (they will still be able to set their spawn point)                  #
 # If you disable this, strange things could happen                                                                   #
 DisableBedsAtNight: true


### PR DESCRIPTION
Closes #28 

(when trying to sleep, for instance)

For reference

https://minecraft.wiki/w/Action_bar

Existing actual log things like command error output are kept in chat, but things like you can't skip during thunderstorm are now done through actionbar (it's totally configurable so server owners can change it). Think for an immersive plugin like this, it would feel cooler!

<img width="300" height="171" alt="image" src="https://github.com/user-attachments/assets/b51d852a-22eb-4c32-9e68-92ab09e41b5d" />
